### PR TITLE
Fix contrast ratio for text in code blocks

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -2791,7 +2791,7 @@ code {
   font-family: "Fira Mono", monospace;
 }
 code {
-  color: #ff8657;
+  color: #803e44;
   background: #f4f4f4;
   display: inline-block;
   padding: 0 0.5rem;


### PR DESCRIPTION
- currently: `2.16` https://webaim.org/resources/contrastchecker/?fcolor=FF8657&bcolor=F4F4F4

<img width="757" height="123" alt="image" src="https://github.com/user-attachments/assets/adc300f9-8b24-4a00-91d2-45ccd253930c" />


- pr: `7.04` https://webaim.org/resources/contrastchecker/?fcolor=803E44&bcolor=F4F4F4

<img width="743" height="151" alt="image" src="https://github.com/user-attachments/assets/a9ee8c2c-a19a-4bf6-806a-829340644d44" />
